### PR TITLE
Use redis.asyncio to replace aioredis due to deprecation

### DIFF
--- a/app/usps_api.py
+++ b/app/usps_api.py
@@ -5,7 +5,7 @@ import time
 import sys
 import html
 import xmltodict
-import aioredis
+from redis import asyncio as aioredis
 import httpx
 
 from . import config

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-import aioredis
+from redis import asyncio as aioredis
 import asyncio
 import pdfkit
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiofiles==23.2.1
-aioredis==2.0.1
 anyio==4.0.0
 astroid==3.0.0
 async-timeout==4.0.3
@@ -33,6 +32,7 @@ pylint==3.0.1
 python-dotenv==1.0.0
 PyYAML==6.0.1
 Quart==0.19.3
+redis==5.0.8
 rfc3986==2.0.0
 sniffio==1.3.0
 toml==0.10.2
@@ -40,7 +40,6 @@ tomli==2.0.1
 tomlkit==0.12.1
 typing_extensions==4.8.0
 uvicorn==0.23.2
-uvloop==0.17.0
 watchfiles==0.20.0
 websockets==11.0.3
 Werkzeug==3.0.3


### PR DESCRIPTION
`aioredis` is [deprecated](https://github.com/aio-libs-abandoned/aioredis-py#-aioredis-is-now-in-redis-py-420rc1-) and doesn't compile on newer python distribution. `redis.asyncio` is identical to `aioredis`, which can resolve the issue with minimal code change.